### PR TITLE
Dockerイメージ作成のCI処理修正

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 


### PR DESCRIPTION
Github Actions で setup-qemu の処理が無いと正常に動かなかったため修正